### PR TITLE
fix: use latest API of sallar/github-contributions-chart

### DIFF
--- a/src/fetch-contributes.js
+++ b/src/fetch-contributes.js
@@ -7,7 +7,7 @@ const $ = require('isomorphic-parse');
 const moment = require("moment");
 
 function getCreatedDateOfGitHubUser(user) {
-    return fetch(`https://github-contributions-api.now.sh/v1/${encodeURIComponent(user)}`)
+    return fetch(`https://github-contributions.now.sh/api/v1/${encodeURIComponent(user)}`)
         .then(res => res.json())
 }
 


### PR DESCRIPTION
## Problem

[sallar/github-contributions-api](https://github.com/sallar/github-contributions-api) が Deprecated になり、 response が空になってしまったため、アプリケーションが正常に動作しなくなった。

```sh
❯ curl 'https://github-contributions-api.now.sh/v1/progfay'
{"years":[],"contributions":[]}
```

## Solution

- [sallar/github-contributions-chart](https://github.com/sallar/github-contributions-chart) が内部で使用している API を利用する。
	- `https://github-contributions.now.sh/api/v1/[username]`


## Current Status

`npm run build` がfailedする。
[desync](https://www.npmjs.com/package/desync) が悪さをしているっぽい。
